### PR TITLE
feat(runner): add `gh` CLI tool

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -11,6 +11,10 @@ on:
         description: "Runner version"
         type: string
         default: "2.315.0" # https://github.com/actions/runner/releases
+      gh_version:
+        description: "GitHub CLI version"
+        type: string
+        default: "2.49.0" # https://github.com/cli/cli/releases
       docker_compose_version:
         description: "Docker compose version"
         type: string
@@ -40,4 +44,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             RUNNER_VERSION=${{ inputs.runner_version }}
+            GH_VERSION=${{ inputs.gh_version }}
             DOCKER_COMPOSE_VERSION=${{ inputs.docker_compose_version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE=ghcr.io/actions/actions-runner
 ARG RUNNER_VERSION=latest
 
 FROM ${BASE_IMAGE}:${RUNNER_VERSION}
-ARG DOCKER_COMPOSE_VERSION=latest
 
 USER root
 RUN apt-get update && \
@@ -10,6 +9,7 @@ RUN apt-get update && \
     build-essential \
     curl \
     git \
+    jq \
     liblzma-dev \
     libmysqlclient-dev \
     libssl-dev \
@@ -20,6 +20,21 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+ARG GH_VERSION=latest
+RUN --mount=type=secret,id=github_token,dst=/run/secrets/github_token \
+    ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" && \
+    if [ "${GH_VERSION}" = "latest" ]; then \
+    TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" && \
+    ([ -n "$TOKEN" ] && CURL_OPTS="-H \"Authorization: token $TOKEN\"" || CURL_OPTS="") && \
+    curl $CURL_OPTS -s "https://api.github.com/repos/cli/cli/releases/latest" | \
+    jq -r --arg arch "$ARCH" '.assets[] | select(.name | endswith("_linux_" + $arch + ".deb")) | .browser_download_url' | \
+    xargs curl -L -o /tmp/gh-cli.deb; \
+    else \
+    curl -L "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_$ARCH.deb" -o /tmp/gh-cli.deb; \
+    fi; \
+    dpkg -i /tmp/gh-cli.deb && rm /tmp/gh-cli.deb
+
+ARG DOCKER_COMPOSE_VERSION=latest
 RUN [ "${DOCKER_COMPOSE_VERSION}" = "latest" ] \
     && curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose \
     || curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Differences from official image:
 
 - Support for using various `setup-*` actions like `ruby/setup-ruby` and
   `actions/setup-go`.
+- Includes the [GitHub CLI](https://cli.github.com) tool (`gh`).
 - Support for using `docker compose`/`docker-compose` commands.
 
 ## Usage


### PR DESCRIPTION
Add the `gh` CLI tool for GitHub, by way of downloading a .deb package file from
GitHub Releases. This allows us to pin the `gh` version, or easily roll it back
should we ever need to.