### PR TITLE
chore(deps): rollback to earlier base actions-runner image version

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,7 +10,7 @@ on:
       runner_version:
         description: "Runner version"
         type: string
-        default: "2.316.1" # https://github.com/actions/runner/releases
+        default: "2.315.0" # https://github.com/actions/runner/releases
       gh_version:
         description: "GitHub CLI version"
         type: string


### PR DESCRIPTION
Since upgrading to 2.316.1 yesterday we've seen numerous instances where the
runner pod and containers all start in response to a job, but fail to actually
pick up and run the job for upwards of +5 minutes.