### PR TITLE
chore(deps): upgrade base image, gh, and docker compose

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,7 +10,7 @@ on:
       runner_version:
         description: "Runner version"
         type: string
-        default: "2.316.1" # https://github.com/actions/runner/releases
+        default: "2.317.0" # https://github.com/actions/runner/releases
       gh_version:
         description: "GitHub CLI version"
         type: string

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -14,7 +14,7 @@ on:
       gh_version:
         description: "GitHub CLI version"
         type: string
-        default: "2.49.0" # https://github.com/cli/cli/releases
+        default: "2.52.0" # https://github.com/cli/cli/releases
       docker_compose_version:
         description: "Docker compose version"
         type: string

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -18,7 +18,7 @@ on:
       docker_compose_version:
         description: "Docker compose version"
         type: string
-        default: "2.27.0" # https://github.com/docker/compose/releases
+        default: "2.28.1" # https://github.com/docker/compose/releases
       platforms:
         description: "Platforms to build for"
         type: string


### PR DESCRIPTION
This is required as the old base runner version of 2.316.1 is deprecated and can
no longer talk to GitHub's API.